### PR TITLE
A less racy way of creating cluster users.

### DIFF
--- a/ansible/jasmin.yml
+++ b/ansible/jasmin.yml
@@ -37,11 +37,20 @@
       file:
         path: "{{ jasmin_homedir }}"
         state: directory
+      run_once: true
 
   roles:
+    # Run the user creation once to create the user home directories
     - role: singleplatform-eng.users
       users: "{{ jasmin_users }}"
       groups_to_create: "{{ jasmin_groups }}"
+      run_once: true
+
+    # Run the user creation again (without home dir) on all nodes
+    - role: singleplatform-eng.users
+      users: "{{ jasmin_users }}"
+      groups_to_create: "{{ jasmin_groups }}"
+      users_create_homedirs: false
 
         
 - hosts:


### PR DESCRIPTION
Users (and home directories) are created on one node first.
Subsequently users are created (without home directory creation)
on all nodes.  This should prevent races on creating the home directory
concurrently on multiple nodes.