### PR TITLE
BeeGFS baseline configuration

### DIFF
--- a/beegfs.yml
+++ b/beegfs.yml
@@ -1,0 +1,29 @@
+---
+# This playbook uses the Ansible OpenStack modules to create a cluster
+# for a BeeGFS server 
+
+- hosts: cluster
+  roles:
+    # Note: The NFS clients are likely to be drawn from across a multi-node
+    # platform deployment. This playbook assumes the existence of a meta-group,
+    # nfs_clients, which contains all clients in the cluster.
+    - role: stackhpc.beegfs
+      beegfs_enable:
+        admon: false
+        mgmt: "{{ inventory_hostname in groups[beegfs_name + '_mds'] }}"
+        meta: "{{ inventory_hostname in groups[beegfs_name + '_mds'] }}"
+        oss: "{{ inventory_hostname in groups[beegfs_name + '_oss'] }}"
+        tuning: "{{ inventory_hostname in groups[beegfs_name + '_oss'] }}"
+        client: "{{ inventory_hostname in groups['beegfs_clients'] }}"
+      beegfs_oss:
+      - dev: "/dev/sdb"
+        port: 8003
+      beegfs_mgmt_host: "{{ groups[beegfs_name + '_mds'] | first }}"
+      beegfs_client:
+      - path: "{{ jasmin_homedir }}"
+        port: 8004
+      beegfs_fstype: "xfs"
+      beegfs_force_format: false
+      beegfs_interfaces: ["eth0"]
+      beegfs_rdma: false
+      beegfs_state: present

--- a/beegfs.yml
+++ b/beegfs.yml
@@ -6,7 +6,7 @@
   roles:
     # Note: The NFS clients are likely to be drawn from across a multi-node
     # platform deployment. This playbook assumes the existence of a meta-group,
-    # nfs_clients, which contains all clients in the cluster.
+    # beegfs_clients, which contains all clients in the cluster.
     - role: stackhpc.beegfs
       beegfs_enable:
         admon: false

--- a/cluster-firewalld.yml
+++ b/cluster-firewalld.yml
@@ -3,10 +3,17 @@
 
 - set_fact:
     private_subnet: "{{ [ansible_default_ipv4.network, ansible_default_ipv4.netmask] | join('/') | ipaddr('net') }}"
-- name: open firewall for local tenant network
+- name: open firewall for local tenant network (TCP)
   firewalld:
     source: "{{ private_subnet }}"
     port: "1-65535/tcp"
+    state: enabled
+    immediate: yes
+    permanent: yes
+- name: open firewall for local tenant network (UDP)
+  firewalld:
+    source: "{{ private_subnet }}"
+    port: "1-65535/udp"
     state: enabled
     immediate: yes
     permanent: yes

--- a/config/beegfs.yml
+++ b/config/beegfs.yml
@@ -1,0 +1,33 @@
+---
+# This name is used for the Heat stack and as a prefix for the
+# cluster node hostnames.
+beegfs_name: beegfs
+
+beegfs_deploy_user: 'centos'
+
+beegfs_net: "caastest-U-internal"
+
+beegfs_groups:
+  - "{{ beegfs_group_mds }}"
+  - "{{ beegfs_group_oss }}"
+
+beegfs_group_mds:
+  name: "mds"
+  flavor: "j1.small"
+  image: "centos-7-20190104"
+  user: "centos"
+  num_nodes: 1
+  root_volume_size: 10
+  node_resource: "Cluster::NodeWithVolume" 
+  nodenet_resource: "Cluster::NodeNet1"
+
+beegfs_group_oss:
+  name: "oss"
+  flavor: "j1.small"
+  image: "centos-7-20190104"
+  user: "centos"
+  num_nodes: 3
+  root_volume_size: 10
+  node_resource: "Cluster::NodeWithVolume" 
+  nodenet_resource: "Cluster::NodeNet1"
+

--- a/config/slurm.yml
+++ b/config/slurm.yml
@@ -24,6 +24,7 @@ slurm_login:
   node_resource: "Cluster::Node" 
   extra_groups:
     - "nfs_clients"
+    - "beegfs_clients"
   nodenet_resource: "Cluster::NodeNet1WithPreallocatedFIP"
   nodenet_fips:
     - uuid: "8723c186-d15f-44d5-9421-e12bf2a03325"
@@ -42,6 +43,7 @@ slurm_compute:
   nodenet_resource: "Cluster::NodeNet1"
   extra_groups:
     - "nfs_clients"
+    - "beegfs_clients"
 
 # Define a list of SLURM partitions to create.
 openhpc_slurm_partitions: 

--- a/roles/requirements.yml
+++ b/roles/requirements.yml
@@ -11,6 +11,7 @@
   name: jasmin.cluster-infra
 - src: https://github.com/stackhpc/ansible-role-cluster-nfs
   name: stackhpc.cluster-nfs
+- src: stackhpc.beegfs
 - src: stackhpc.openhpc
 - src: stackhpc.os-container-infra
 - src: stackhpc.os-config

--- a/slurm-beegfs-infra.yml
+++ b/slurm-beegfs-infra.yml
@@ -1,0 +1,93 @@
+---
+# This playbook uses the Ansible OpenStack modules to create a cluster
+# using a number of baremetal compute node instances, and configure it
+# for a SLURM partition
+- hosts: openstack
+  roles:
+    - role: jasmin.cluster-infra
+      cluster_auth_type: "{{ openstack_auth_type }}"
+      cluster_auth: "{{ openstack_auth }}"
+      cluster_network: "caastest-U-internal"
+      cluster_name: "{{ slurm_name }}"
+      cluster_groups: "{{ slurm_groups }}"
+      cluster_deploy_user: "{{ slurm_deploy_user }}"
+      cluster_net: "{{ slurm_net }}"
+      cluster_gw_group: "{{ slurm_gw_group }}"
+
+    - role: jasmin.cluster-infra
+      cluster_auth_type: "{{ openstack_auth_type }}"
+      cluster_auth: "{{ openstack_auth }}"
+      cluster_network: "caastest-U-internal"
+      cluster_name: "{{ beegfs_name }}"
+      cluster_groups: "{{ beegfs_groups }}"
+      cluster_deploy_user: "{{ beegfs_deploy_user }}"
+      cluster_net: "{{ beegfs_net }}"
+      cluster_gw_group: "{{ slurm_gw_group }}"
+
+- hosts:
+    - cluster
+  become: true
+  tasks:
+    - import_tasks: cluster-hosts.yml 
+    - import_tasks: cluster-firewalld.yml 
+
+- hosts:
+    - cluster
+  become: true  
+  roles:
+    - role: resmo.ntp
+
+- import_playbook: beegfs.yml
+
+- hosts:
+    - "{{ slurm_name }}_login"
+    - "{{ slurm_name }}_compute"
+  become: yes
+  pre_tasks:
+
+    - name: Ensure user home dir root exists
+      file:
+        path: "{{ jasmin_homedir }}"
+        state: directory
+      run_once: true
+
+  roles:
+    # Run the user creation once to create the user home directories
+    - role: singleplatform-eng.users
+      users: "{{ jasmin_users }}"
+      groups_to_create: "{{ jasmin_groups }}"
+      run_once: true
+
+    # Run the user creation again (without home dir) on all nodes
+    - role: singleplatform-eng.users
+      users: "{{ jasmin_users }}"
+      groups_to_create: "{{ jasmin_groups }}"
+      users_create_homedirs: false
+
+        
+- hosts:
+    - "{{ slurm_name }}_login"
+    - "{{ slurm_name }}_compute"
+  become: yes
+  pre_tasks:
+
+    - name: Ensure the OpenHPC package repo rpm is present
+      yum:
+        name: "https://github.com/openhpc/ohpc/releases/download/v1.3.GA/ohpc-release-1.3-1.el7.x86_64.rpm"
+        state: present
+
+    - name: Ensure latest python is present
+      yum:
+        name: python
+        state: latest
+
+  roles:
+    - role: stackhpc.openhpc
+      openhpc_enable:
+        control: "{{ inventory_hostname in groups[slurm_name + '_login'] }}"
+        batch: "{{ inventory_hostname in groups[slurm_name + '_compute'] }}"
+        runtime: true
+      openhpc_cluster_name: "{{ slurm_name }}"
+      openhpc_slurm_partitions: "{{ openhpc_slurm_partitions }}"
+      openhpc_slurm_control_host: "{{ groups[slurm_name + '_login'] | first }}"
+

--- a/slurm-beegfs-infra.yml
+++ b/slurm-beegfs-infra.yml
@@ -1,6 +1,6 @@
 ---
 # This playbook uses the Ansible OpenStack modules to create a cluster
-# using a number of baremetal compute node instances, and configure it
+# using a number of compute node instances, and configure it
 # for a SLURM partition
 - hosts: openstack
   roles:


### PR DESCRIPTION
This PR introduces support for BeeGFS as a Cluster-as-a-Service filesystem.  It can replace NFS as the cluster network filesystem and in this example it is mounted as the user home directories.