### PR TITLE
Add playbooks to drain and resume Slurm compute nodes

### DIFF
--- a/drain.yml
+++ b/drain.yml
@@ -1,0 +1,20 @@
+---
+# Ansible playbook to drain Slurm compute nodes. Waits for compute nodes to be
+# drained for up to a day.
+#
+# Variables:
+# - nodes_to_drain: list of compute nodes to drain
+
+- name: Drain compute nodes
+  become: yes
+  shell: "scontrol update nodename={{ item }} state=DRAIN reason='maintenance'"
+  # If called with hosts: <group>, execute only on the first host of the group
+  run_once: true
+  with_items: "{{ nodes_to_drain }}"
+
+- name: Check nodes have drained
+  shell: "sinfo --noheader --Node --format='%N' --states=DRAINED"
+  register: drained_nodes
+  until: "drained_nodes.stdout_lines is superset(nodes_to_drain)"
+  delay: 10
+  retries: 8640

--- a/resume.yml
+++ b/resume.yml
@@ -1,0 +1,20 @@
+---
+# Ansible playbook to resume Slurm compute nodes. Waits for compute nodes to
+# change state for 5 minutes.
+#
+# Variables:
+# - nodes_to_resume: list of compute nodes to resume
+
+- name: Resume compute nodes
+  become: yes
+  shell: "scontrol update nodename={{ item }} state=RESUME"
+  # If called with hosts: <group>, execute only on the first host of the group
+  run_once: true
+  with_items: "{{ nodes_to_resume }}"
+
+- name: Check nodes have resumed
+  shell: "sinfo --noheader --Node --format='%N' --states=ALLOC,IDLE"
+  register: resumed_nodes
+  until: "resumed_nodes.stdout_lines is superset(nodes_to_resume)"
+  delay: 10
+  retries: 30


### PR DESCRIPTION
Based on Holly's code from https://github.com/cedadev/jasmin-appliances/pull/8