### PR TITLE
only run firewall tasks if firewalld is running

### DIFF
--- a/cluster-firewalld.yml
+++ b/cluster-firewalld.yml
@@ -1,19 +1,31 @@
 ---
 # Playbook to open firewall access to all hosts on the local IP subnet
 
-- set_fact:
-    private_subnet: "{{ [ansible_default_ipv4.network, ansible_default_ipv4.netmask] | join('/') | ipaddr('net') }}"
-- name: open firewall for local tenant network (TCP)
-  firewalld:
-    source: "{{ private_subnet }}"
-    port: "1-65535/tcp"
-    state: enabled
-    immediate: yes
-    permanent: yes
-- name: open firewall for local tenant network (UDP)
-  firewalld:
-    source: "{{ private_subnet }}"
-    port: "1-65535/udp"
-    state: enabled
-    immediate: yes
-    permanent: yes
+- name: populate service facts to check if firewalld is running
+  service_facts:
+
+- block:
+
+    - set_fact:
+        private_subnet: "{{ [ansible_default_ipv4.network, ansible_default_ipv4.netmask] | join('/') | ipaddr('net') }}"
+    - name: install the python bindings for firewalld
+      package:
+        name: python-firewall
+        state: installed
+    - name: open firewall for local tenant network (TCP)
+      firewalld:
+        source: "{{ private_subnet }}"
+        port: "1-65535/tcp"
+        state: enabled
+        immediate: yes
+        permanent: yes
+    - name: open firewall for local tenant network (UDP)
+      firewalld:
+        source: "{{ private_subnet }}"
+        port: "1-65535/udp"
+        state: enabled
+        immediate: yes
+        permanent: yes
+
+  when: (ansible_facts.services['firewalld.service'] is defined) and
+        (ansible_facts.services['firewalld.service'].state == "running")


### PR DESCRIPTION
when testing I got these errors:

```
TASK [open firewall for local tenant network (TCP)] *************************************************************************
task path: /home/centos/jasmin-appliances/cluster-firewalld.yml:6
fatal: [jasmin-pablo-login-0]: FAILED! => {"changed": false, "msg": "Python Module not found: firewalld and its python module are required for this module, version 0.2.11 or newer required (0.3.9 or newer for offline operations)"}
```

```
TASK [open firewall for local tenant network (TCP)] *******************************************************************************************************************************
task path: /home/centos/jasmin-appliances/cluster-firewalld.yml:10
fatal: [jasmin-pablo-login-0]: FAILED! => {"changed": false, "module_stderr": "Shared connection to 10.34.29.73 closed.\r\n", "module_stdout": "ERROR: Failed to load '/etc/firewalld/firewalld.conf': [Errno 2] No such file or directory: '/etc/firewalld/firewalld.conf'\r\nWARNING: Using fallback firewalld configuration settings.\r\nERROR: No icmptypes found.\r\nERROR: No services found.\r\nFATAL ERROR: Zone 'block' is not available.\r\nFATAL ERROR: Zone 'drop' is not available.\r\nFATAL ERROR: Zone 'trusted' is not available.\r\n", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}
``` 

this PR should workaround both by installing the required python libraries and only configuring firewalld in case it's installed and running