### PR TITLE
Support package update on BeeGFS clusters

### DIFF
--- a/beegfs-infra.yml
+++ b/beegfs-infra.yml
@@ -28,6 +28,10 @@
 
 - import_playbook: beegfs.yml
 
+- hosts: beegfs_servers
+  tasks:
+    - include: tasks/update.yml
+
 - hosts: openstack
   roles:
     - role: jasmin.cluster-infra

--- a/group_vars/openstack/beegfs
+++ b/group_vars/openstack/beegfs
@@ -25,7 +25,7 @@ beegfs_group_mds:
 
 beegfs_group_oss:
   name: "oss"
-  flavor: "j1.small"
+  flavor: "j2.small"
   image: "centos-7-20190104"
   user: "centos"
   num_nodes: "{{ cluster_num_workers }}"


### PR DESCRIPTION
Package update hangs when using j1.small instances for OSS nodes, with
the `yum` process stuck in `balance_dirty_pages.isra.20`. This only
happens when applying updates via Ansible, not when running `yum update`
directly from a shell. It is possible that the extra memory consumption
caused by Ansible/Python triggers this behaviour.

Switch to j2.small instances which have twice the amount of RAM to avoid
this issue.