### PR TITLE
Prevent failure to extract output if node_groups is null

### DIFF
--- a/tasks/infra/provision.yml
+++ b/tasks/infra/provision.yml
@@ -9,7 +9,7 @@
 
     - name: Extract output of existing ephemeral bastion
       set_fact:
-        cluster_existing_gw_ip: "{{ ((openstack_stack_outputs | json_query(query)) + [omit]) | first }}"
+        cluster_existing_gw_ip: "{{ ((openstack_stack_outputs | json_query(query) | default([], true)) + [omit]) | first }}"
       vars:
         query: "node_groups[?name=='{{ deploy_gw_group_name }}'].nodes[0].ip"
       when: openstack_stack_outputs is defined


### PR DESCRIPTION
If a previous stack update failed, the node_groups output value may be
null. This makes this task fail with:

Unexpected templating type error occurred on ({{ ((openstack_stack_outputs | json_query(query)) + [omit]) | first }}): unsupported operand type(s) for +: \'NoneType\' and \'list\'