### PR TITLE
Only check mount when using NFS

### DIFF
--- a/playbooks/validation.yml
+++ b/playbooks/validation.yml
@@ -28,7 +28,10 @@
 
     - fail:
         msg: "filesystem not mounted on NFS clients"
-      when: not check_mount
+      when:
+        - hostvars.localhost.storage_type is defined
+        - hostvars.localhost.storage_type == 'nfs'
+        - not check_mount
 
     - name: check status of munge process
       shell: "systemctl status munge"


### PR DESCRIPTION
The `ansible_mounts` variable does not include BeeGFS mountpoints.