### PR TITLE
Fix /etc/hosts logic

### DIFF
--- a/tasks/network/hosts.yml
+++ b/tasks/network/hosts.yml
@@ -4,7 +4,7 @@
 - name: Populate /etc/hosts
   lineinfile:
     path: /etc/hosts
-    regexp: '^{{ hostvars[host].ansible_default_ipv4.address | replace(".", "\.") }}'
+    regexp: "{{ hostvars[host].ansible_hostname }}"
     line: "{{ hostvars[host].ansible_default_ipv4.address }} {{ hostvars[host].ansible_fqdn }} {{ hostvars[host].ansible_hostname }}"
   loop: "{{ ansible_play_hosts }}"
   loop_control:


### PR DESCRIPTION
The previous logic would make multiple lines for the same hostname if the IP changed for any reason (for example if the stack for a dependency is re-created).